### PR TITLE
feat: add homoglyph encoding plugin (Unicode confusables)

### DIFF
--- a/docs/02_builtin.md
+++ b/docs/02_builtin.md
@@ -129,6 +129,7 @@ The following list provides an overview of each build-in plugin, further informa
 | `caesar` | Encoding | Applies a Caesar cipher to the text, shifting letters by a specified number of positions. | `shift` (number of positions to shift, default: 3) |
 | `decimal` | Encoding | Encodes text as space-separated ASCII/Unicode decimal codepoint values. | `hint` (show the literal plaintext string `decimal` in the encoded output, default true) |
 | `hex` | Encoding | Encodes text into its hexadecimal representation. | N/A |
+| `homoglyph` | Encoding, Obfuscation | Substitutes Latin characters with visually-identical Unicode confusables (Cyrillic/Greek). Output looks unchanged to a human but uses different code points, evading ASCII keyword/regex filters. | `ratio` (fraction of mappable characters to substitute, 0.0-1.0, default: 1.0)<br> `seed` (optional integer seed for reproducible partial substitution) |
 | `morse` | Encoding | Encodes text into Morse code. | N/A |
 | `octal` | Encoding | Encodes text as space-separated ASCII/Unicode octal codepoint values. | `hint` (show the literal plaintext string `octal` in the encoded output, default true) |
 | `best_of_n` | Obfuscation, Attack-Based | Implements ["Best-of-N Jailbreaking" John Hughes et al., 2024](https://arxiv.org/html/2412.03556v1#A1) to apply character scrambling, random capitalization, and character noising. | `variants` (number of variations to generate, default: 50) |

--- a/spikee/plugins/homoglyph.py
+++ b/spikee/plugins/homoglyph.py
@@ -91,7 +91,7 @@ class HomoglyphPlugin(BasicPlugin):
 
     def get_description(self) -> ModuleDescriptionHint:
         return (
-            [ModuleTag.ENCODING, ModuleTag.OBFUSCATION],
+            [ModuleTag.ENCODING],
             "Substitutes Latin characters with visually-identical Unicode confusables.",
         )
 

--- a/spikee/plugins/homoglyph.py
+++ b/spikee/plugins/homoglyph.py
@@ -1,0 +1,150 @@
+"""
+Homoglyph Plugin
+
+This plugin substitutes Latin (ASCII) characters with visually-identical Unicode
+"confusables" drawn from the Cyrillic and Greek scripts. To a human reader the text
+looks unchanged ("paypal" still reads as "paypal"), but every substituted character has
+a different code point, which defeats naive keyword/regex filters and byte-level
+denylists that assume ASCII.
+
+This is distinct from the existing plugins:
+    - `ascii_smuggler` hides text in invisible Unicode tag characters (U+E00xx).
+    - `1337` replaces letters with numerals/symbols, which is visually obvious.
+Homoglyph substitution keeps the text human-legible while changing the underlying bytes.
+
+By default every mappable character is substituted (``ratio=1.0``), which is fully
+deterministic. A lower ``ratio`` substitutes only that fraction of mappable characters,
+producing mixed-script text; pass ``seed`` for reproducible partial substitution.
+
+Usage:
+    spikee generate --plugins homoglyph
+    spikee generate --plugins homoglyph --plugin-options "homoglyph:ratio=0.5"
+    spikee generate --plugins homoglyph --plugin-options "homoglyph:ratio=0.5,seed=42"
+
+Reference:
+    https://www.unicode.org/Public/security/latest/confusables.txt
+    https://en.wikipedia.org/wiki/IDN_homograph_attack
+
+Parameters:
+    text (str): The input text to be transformed.
+    ratio (float): Fraction of mappable characters to substitute, in [0.0, 1.0]
+        (default: 1.0). At 1.0 substitution is deterministic; below 1.0 a random
+        subset is chosen.
+    seed (int, optional): Seed for the random subset when ``ratio`` < 1.0, for
+        reproducible output.
+    exclude_patterns (List[str], optional): Supplied by the framework. Substrings
+        matching these regex patterns are preserved as-is.
+
+Returns:
+    str: The transformed text with Latin characters replaced by confusables.
+"""
+
+import random
+from typing import Dict
+
+from spikee.templates.basic_plugin import BasicPlugin
+from spikee.utilities.enums import ModuleTag
+from spikee.utilities.hinting import ModuleDescriptionHint, ModuleOptionsHint
+from spikee.utilities.modules import parse_options
+
+
+class HomoglyphPlugin(BasicPlugin):
+    DEFAULT_RATIO = 1.0
+
+    # Latin -> visually-identical Cyrillic/Greek confusable.
+    # Only high-confidence, single-character mappings are included; unmapped
+    # characters are passed through unchanged.
+    CONFUSABLES: Dict[str, str] = {
+        # lowercase
+        "a": "а",  # CYRILLIC SMALL LETTER A
+        "c": "с",  # CYRILLIC SMALL LETTER ES
+        "d": "ԁ",  # CYRILLIC SMALL LETTER KOMI DE
+        "e": "е",  # CYRILLIC SMALL LETTER IE
+        "g": "ɡ",  # LATIN SMALL LETTER SCRIPT G
+        "h": "һ",  # CYRILLIC SMALL LETTER SHHA
+        "i": "і",  # CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+        "j": "ј",  # CYRILLIC SMALL LETTER JE
+        "o": "о",  # CYRILLIC SMALL LETTER O
+        "p": "р",  # CYRILLIC SMALL LETTER ER
+        "s": "ѕ",  # CYRILLIC SMALL LETTER DZE
+        "v": "ѵ",  # CYRILLIC SMALL LETTER IZHITSA
+        "x": "х",  # CYRILLIC SMALL LETTER HA
+        "y": "у",  # CYRILLIC SMALL LETTER U
+        # uppercase
+        "A": "А",  # CYRILLIC CAPITAL LETTER A
+        "B": "В",  # CYRILLIC CAPITAL LETTER VE
+        "C": "С",  # CYRILLIC CAPITAL LETTER ES
+        "E": "Е",  # CYRILLIC CAPITAL LETTER IE
+        "H": "Н",  # CYRILLIC CAPITAL LETTER EN
+        "I": "Ι",  # GREEK CAPITAL LETTER IOTA
+        "J": "Ј",  # CYRILLIC CAPITAL LETTER JE
+        "K": "К",  # CYRILLIC CAPITAL LETTER KA
+        "M": "М",  # CYRILLIC CAPITAL LETTER EM
+        "N": "Ν",  # GREEK CAPITAL LETTER NU
+        "O": "О",  # CYRILLIC CAPITAL LETTER O
+        "P": "Р",  # CYRILLIC CAPITAL LETTER ER
+        "S": "Ѕ",  # CYRILLIC CAPITAL LETTER DZE
+        "T": "Т",  # CYRILLIC CAPITAL LETTER TE
+        "X": "Х",  # CYRILLIC CAPITAL LETTER HA
+        "Y": "Ү",  # CYRILLIC CAPITAL LETTER STRAIGHT U
+    }
+
+    def get_description(self) -> ModuleDescriptionHint:
+        return (
+            [ModuleTag.ENCODING, ModuleTag.OBFUSCATION],
+            "Substitutes Latin characters with visually-identical Unicode confusables.",
+        )
+
+    def get_available_option_values(self) -> ModuleOptionsHint:
+        """Return supported attack options; Tuple[options (default is first), llm_required]"""
+        return [
+            "ratio=1.0",
+            "ratio=N (0.0-1.0, fraction of mappable characters to substitute)",
+            "seed=N (optional integer seed for reproducible partial substitution)",
+        ], False
+
+    def plugin_transform(self, text: str, plugin_option: str = "") -> str:
+        """
+        Substitutes Latin characters with Unicode confusables.
+
+        Args:
+            text (str): The input text (or chunk thereof).
+            plugin_option (str, optional): Plugin options string, e.g.
+                "ratio=0.5,seed=42".
+
+        Returns:
+            str: The transformed text.
+        """
+        ratio, seed = self._parse_options(plugin_option)
+
+        if ratio >= 1.0:
+            return "".join(self.CONFUSABLES.get(c, c) for c in text)
+
+        if ratio <= 0.0:
+            return text
+
+        rng = random.Random(seed)
+        return "".join(
+            self.CONFUSABLES[c] if (c in self.CONFUSABLES and rng.random() < ratio) else c
+            for c in text
+        )
+
+    def _parse_options(self, plugin_option: str):
+        """Parse the ``ratio`` and ``seed`` options, falling back to defaults."""
+        opts = parse_options(plugin_option)
+
+        ratio = self.DEFAULT_RATIO
+        if "ratio" in opts:
+            try:
+                ratio = max(0.0, min(1.0, float(opts["ratio"])))
+            except ValueError:
+                ratio = self.DEFAULT_RATIO
+
+        seed = None
+        if "seed" in opts:
+            try:
+                seed = int(opts["seed"])
+            except ValueError:
+                seed = None
+
+        return ratio, seed

--- a/tests/functional/test_spikee_generate/test_plugins.py
+++ b/tests/functional/test_spikee_generate/test_plugins.py
@@ -171,6 +171,52 @@ class TestApplyPlugin:
         assert isinstance(result, list)
         assert any("h3ll0" in get_content(r) for r in result)
 
+    def test_homoglyph_default_full_substitution(self, workspace_dir):
+        """homoglyph substitutes every mappable Latin char with a confusable by default."""
+        os.chdir(workspace_dir)  # Ensure we're in the workspace for plugin loading
+
+        plugins = load_plugins(["homoglyph"])
+        plugin_name, plugin_module = plugins[0]
+
+        result = apply_plugin(plugin_name, plugin_module, "paypal", None, None)
+
+        assert isinstance(result, list)
+        outputs = [get_content(r) for r in result]
+        # 'p'->U+0440, 'a'->U+0430, 'y'->U+0443; 'l' has no mapping and is preserved.
+        expected = "раураl"
+        assert any(out == expected for out in outputs)
+        # Visually identical to "paypal" but contains no ASCII letters except 'l'.
+        assert any(out != "paypal" and len(out) == len("paypal") for out in outputs)
+
+    def test_homoglyph_ratio_zero_is_noop(self, workspace_dir):
+        """ratio=0.0 leaves the input unchanged (no substitution)."""
+        os.chdir(workspace_dir)  # Ensure we're in the workspace for plugin loading
+
+        plugins = load_plugins(["homoglyph"])
+        plugin_name, plugin_module = plugins[0]
+
+        result = apply_plugin(
+            plugin_name, plugin_module, "paypal", None, {"homoglyph": "ratio=0.0"}
+        )
+
+        assert [get_content(r) for r in result] == ["paypal"]
+
+    def test_homoglyph_partial_ratio_is_reproducible_with_seed(self, workspace_dir):
+        """A fixed seed yields deterministic partial substitution that differs from input."""
+        os.chdir(workspace_dir)  # Ensure we're in the workspace for plugin loading
+
+        plugins = load_plugins(["homoglyph"])
+        plugin_name, plugin_module = plugins[0]
+
+        text = "the quick brown fox"
+        opts = {"homoglyph": "ratio=0.5,seed=42"}
+        first = [get_content(r) for r in apply_plugin(plugin_name, plugin_module, text, None, opts)]
+        second = [get_content(r) for r in apply_plugin(plugin_name, plugin_module, text, None, opts)]
+
+        assert first == second  # reproducible
+        assert any(out != text for out in first)  # something was substituted
+        assert any(out != text and len(out) == len(text) for out in first)  # 1:1 length
+
     def test_upper_legacy_matches_oop(self, workspace_dir):
         """test_upper_legacy (module-level function) produces the same output as the OOP version."""
         os.chdir(workspace_dir)  # Ensure we're in the workspace for plugin loading


### PR DESCRIPTION
## Summary
Adds a built-in `homoglyph` plugin that substitutes Latin characters with visually-identical Unicode confusables (Cyrillic/Greek), producing payloads that read identically to a human but carry different code points — a transform that defeats naive ASCII keyword/regex filters and is not covered by any existing Spikee plugin.

## Problem / motivation
Spikee already ships character-level evasions, but each occupies a different niche:
- `ascii_smuggler` hides text in **invisible** Unicode tag characters (U+E00xx) — the text disappears from the UI entirely.
- `1337` swaps letters for numerals/symbols — **visually obvious** to a reader.

Neither covers the most common real-world evasion against text-based guardrails: replacing characters with *look-alikes* so the payload stays human-legible while becoming opaque to filters that assume ASCII. Homograph substitution is a well-documented technique (the IDN homograph attack family) and a standard test case for content-safety classifiers and denylist-based input filters. Without it, Spikee cannot generate this class of evasion when building datasets to exercise guardrails.

## Change
- New plugin `spikee/plugins/homoglyph.py`, subclassing `BasicPlugin` and mirroring the structure of `base64.py` / `1337.py` / `caesar.py`:
  - Maps Latin characters to high-confidence Unicode confusables (Cyrillic/Greek single-character mappings); unmapped characters pass through unchanged. Subclasses `BasicPlugin` like `caesar.py` / `1337.py`.
  - Tagged `[ModuleTag.ENCODING, ModuleTag.OBFUSCATION]`.
  - `ratio` option (default `1.0`) controls the fraction of mappable characters substituted; at `1.0` output is fully deterministic, below `1.0` a random subset is chosen.
  - Optional `seed` option makes partial substitution reproducible.
  - Inherits framework `exclude_patterns` handling from `BasicPlugin` (no reimplementation).
- Adds a row to the plugin table in `docs/02_builtin.md`.
- Adds three tests to `tests/functional/test_spikee_generate/test_plugins.py` covering deterministic full substitution, the `ratio=0.0` no-op, and seeded reproducible partial substitution.

No changes to public interfaces, dependencies, or existing plugins. Pure standard-library implementation.

## Security rationale
Homoglyph / confusable substitution is the canonical bypass for input filters and content-safety classifiers that operate on ASCII or exact-match denylists. It maps directly to **OWASP LLM Top 10 (2025) LLM01: Prompt Injection** — specifically obfuscation-based filter evasion — and the broader weakness class **CWE-176: Improper Handling of Unicode Encoding**. The IDN homograph attack (the phishing precedent for this technique) is tracked under **CAPEC-632: Homograph Attack via Homoglyphs**. Adding this transform lets red teams and guardrail authors measure whether a control normalizes/NFKC-folds input and rejects mixed-script tokens, rather than silently passing look-alike payloads. It complements `ascii_smuggler` (invisible-character smuggling) to give coverage of both major Unicode-abuse evasion families.

## Testing / validation
Validated locally against a clean checkout in an isolated venv (Python 3.14, editable install):

```
pytest tests/functional/test_spikee_generate/test_plugins.py -q
33 passed in 17.21s
```

- `test_homoglyph_default_full_substitution` — asserts the exact deterministic mapping (`"paypal"` → `"раураl"`, with the unmapped `l` preserved) and equal length / non-ASCII output.
- `test_homoglyph_ratio_zero_is_noop` — asserts `ratio=0.0` returns the input unchanged.
- `test_homoglyph_partial_ratio_is_reproducible_with_seed` — asserts seeded partial substitution is reproducible across runs, mutates the input, and preserves a 1:1 character mapping.

Also confirmed `spikee list plugins` registers the plugin (`homoglyph  Encoding, Obfuscation`) and that the existing suite is unaffected (full file: 33/33 passing, no regressions).

False-positive risk is low: the plugin is additive (new file + one doc row + three new tests), touches no shared code paths, and the default `ratio=1.0` path is fully deterministic.
