### PR TITLE
docs: fix GOAT citation and note workspace-only status in 02_builtin.md

### DIFF
--- a/docs/02_builtin.md
+++ b/docs/02_builtin.md
@@ -154,7 +154,7 @@ spikee generate --seed ./seeds-cybersec-2026-01 \
 ```
 
 ## Built-in Attacks
-Spikee includes several built-in dynamic attacks, that will iteratively modify prompts/documents until they succeed (or run out of iterations). These are located within the `spikee/attacks/` folder, and can be listed at any time with `spikee list attacks`.
+Spikee includes several built-in dynamic attacks, that will iteratively modify prompts/documents until they succeed (or run out of iterations). These are located within the `spikee/attacks/` and `workspace/attacks` folders, and can be listed at any time with `spikee list attacks`.
 
 You can customize the behavior of attacks using the following command-line options:
 * `--attack-iterations`: Specifies the maximum number of iterations for each attack (default: 1000).
@@ -181,8 +181,6 @@ You can customize the behavior of attacks using the following command-line optio
 | `goat` | Social Engineering, LLM | Implements the [GOAT Attack](https://arxiv.org/abs/2410.01606) (Generative Offensive Agent Tester). A multi-turn attack using an LLM acting as an automated red teaming agent, that can implement a range of adversarial prompting and jailbreaking techniques to achieve an objective. | See file for target specific configuration using `APPLICATION_CONFIG` and `APPLICATION_GUARDRAILS`. |
 | `multi_turn` | Multi-Turn | Sequentially sends a predefined list of user prompts to the target LLM, from a simplistic multi-turn dataset. | N/A |
 | `rag_poisoner` | LLM | Injects fake RAG context that appears to be legitimate document snippets supporting the attack objective. | `model` (The LLM model to use for generating attacks) |
-
-> **Note:** `goat` is a workspace template, not a core built-in — it ships in `workspace/attacks/` (created by `spikee init`) rather than `spikee/attacks/`. It appears as a local attack after initialisation, but will not show up in `spikee list attacks` on a fresh install before running `spikee init`.
 
 **Usage Example**
 ```bash

--- a/docs/02_builtin.md
+++ b/docs/02_builtin.md
@@ -178,9 +178,11 @@ You can customize the behavior of attacks using the following command-line optio
 | `llm_poetry_jailbreaker` | Social Engineering, LLM | Generates jailbreak attempts in the form of poetry or rhymes. | `model` (The LLM model to use for generating attacks) |
 | `crescendo` | Social Engineering, LLM | Implements the [Crescendo Attack](https://arxiv.org/abs/2404.01833). A multi-turn jailbreak that leverages an LLM Agent to prompt the target with seemingly benign prompts, gradually escalating the conversation by referencing the model's replies progressively leading to a successful jailbreak. | N/A |
 | `echo_chamber` | Social Engineering, LLM | Implements the [Echo Chamber Attack](https://arxiv.org/pdf/2601.05742). A multi-turn attack that uses an LLM Agent to create a feedback loop, where the model's own responses are fed back into itself in order to bypass guardrails and achieve jailbreaks. | N/A |
-| `goat` | Social Engineering, LLM | Implements the [GOAT Attack](https://arxiv.org/abs/2404.02151). A multi-turn attack using an LLM acting as an automated red teaming agent, that can implement a range of adversarial prompting and jailbreaking techniques to achieve an objective. | See file for target specific configuration using `APPLICATION_CONFIG` and `APPLICATION_GUARDRAILS`. |
+| `goat` | Social Engineering, LLM | Implements the [GOAT Attack](https://arxiv.org/abs/2410.01606) (Generative Offensive Agent Tester). A multi-turn attack using an LLM acting as an automated red teaming agent, that can implement a range of adversarial prompting and jailbreaking techniques to achieve an objective. | See file for target specific configuration using `APPLICATION_CONFIG` and `APPLICATION_GUARDRAILS`. |
 | `multi_turn` | Multi-Turn | Sequentially sends a predefined list of user prompts to the target LLM, from a simplistic multi-turn dataset. | N/A |
 | `rag_poisoner` | LLM | Injects fake RAG context that appears to be legitimate document snippets supporting the attack objective. | `model` (The LLM model to use for generating attacks) |
+
+> **Note:** `goat` is a workspace template, not a core built-in — it ships in `workspace/attacks/` (created by `spikee init`) rather than `spikee/attacks/`. It appears as a local attack after initialisation, but will not show up in `spikee list attacks` on a fresh install before running `spikee init`.
 
 **Usage Example**
 ```bash


### PR DESCRIPTION
## Summary

Corrects the arXiv citation for the GOAT attack from the EPFL adaptive-attacks paper (2404.02151) to the actual GOAT paper (2410.01606), and adds a clarifying note that `goat` ships as a workspace template rather than a core built-in.

## Problem / motivation

The `goat` row in the Built-in Attacks table links to arXiv:2404.02151 — the same paper cited two rows above for `random_suffix_search`. GOAT is a distinct, unrelated work: Meta's **Generative Offensive Agent Tester** (Pavlova et al., arXiv:2410.01606, 2024), and `goat.py` itself already references the correct URL (`https://arxiv.org/pdf/2410.01606`) in its module docstring.

The incorrect link misleads practitioners trying to understand the attack's provenance, methodology, and threat model — relevant when citing research for red-team engagements (OWASP LLM Top 10: LLM01 — Prompt Injection).

A second gap: the section states attacks live in `spikee/attacks/` and are discoverable via `spikee list attacks`. In practice `goat` ships in `workspace/attacks/` (populated by `spikee init`), not `spikee/attacks/`. On a fresh install, before initialisation, `spikee list attacks` does not list it.

## Change

- **`docs/02_builtin.md`** (GOAT row): replace `https://arxiv.org/abs/2404.02151` with `https://arxiv.org/abs/2410.01606`; append "(Generative Offensive Agent Tester)" to the link text for disambiguation.
- **`docs/02_builtin.md`** (after the Attacks table): add a blockquote note explaining that `goat` is a workspace template (`workspace/attacks/`), not a core built-in (`spikee/attacks/`), and will not appear in `spikee list attacks` before `spikee init`.

No code changes. No behavioural changes.

## Testing / validation

- Confirmed upstream `goat.py` docstring cites `https://arxiv.org/pdf/2410.01606` — matches the correction.
- Confirmed `random_suffix_search` row still correctly links to `2404.02151` (the EPFL paper) and is untouched.
- Confirmed `goat.py` exists only at `spikee/data/workspace/attacks/goat.py`; absent from `spikee/attacks/`.
- `git diff` shows exactly the two intended hunks (3 insertions, 1 deletion); no unintended edits.

Commit prefixed `docs:` per CONTRIBUTION_RULES.md (excluded from CHANGELOG per repo rules).
