### PR TITLE
feat: add base32 encoding plugin

### DIFF
--- a/docs/02_builtin.md
+++ b/docs/02_builtin.md
@@ -124,6 +124,7 @@ The following list provides an overview of each build-in plugin, further informa
 | `1337` | Encoding | Transforms text into "leet speak" by replacing certain letters with numbers or symbols. | N/A |
 | `ascii_smuggler` | Encoding | Transforms ASCII text into a series of Unicode rags that are generally invisible to most UI elements (bypassing content filters). | N/A |
 | `atbash` | Encoding | Transforms the input text with the Atbash cipher. Maps each letter to its counterpart on the other end of the alphabet (A <->Z, B<->Y, etc.), preserving case. | `hint` (show the literal plaintext string `atbash` in the encoded output, default true)  |
+| `base32` | Encoding | Encodes text using Base32 encoding (A-Z2-7 alphabet), tokenising differently from Base64. | N/A |
 | `base64` | Encoding | Encodes text using Base64 encoding. | N/A |
 | `binary` | Encoding | Encodes text as space-separated ASCII/Unicode binary codepoint values (8 bits each).| N/A  |
 | `caesar` | Encoding | Applies a Caesar cipher to the text, shifting letters by a specified number of positions. | `shift` (number of positions to shift, default: 3) |

--- a/spikee/plugins/base32.py
+++ b/spikee/plugins/base32.py
@@ -1,0 +1,48 @@
+"""
+Base32 Encoding Plugin
+
+This plugin transforms the input text into Base32 encoding.
+
+Base32 uses a different alphabet (A-Z and 2-7) from Base64, so it tokenises
+differently and can slip past guardrails or filters that only account for
+Base64-style payloads.
+
+Usage:
+    spikee generate --plugins base32
+
+Parameters:
+    text (str): The input text to be transformed.
+
+Returns:
+    str: The transformed text in Base32 encoding.
+"""
+
+import base64
+from typing import List, Optional
+
+from spikee.templates.plugin import Plugin
+from spikee.utilities.hinting import ModuleDescriptionHint, ModuleOptionsHint
+from spikee.utilities.enums import ModuleTag
+
+
+class Base32(Plugin):
+    def get_description(self) -> ModuleDescriptionHint:
+        return [ModuleTag.ENCODING], "Transforms text into Base32 encoding."
+
+    def get_available_option_values(self) -> ModuleOptionsHint:
+        """Return supported attack options; Tuple[options (default is first), llm_required]"""
+        return [], False
+
+    def transform(
+        self, content: str, exclude_patterns: Optional[List[str]] = None
+    ) -> str:
+        """
+        Transforms the input text into Base32 encoding.
+
+        Args:
+            content (str): The input text.
+
+        Returns:
+            str: The transformed text in Base32 encoding.
+        """
+        return base64.b32encode(content.encode()).decode()

--- a/tests/functional/test_spikee_list.py
+++ b/tests/functional/test_spikee_list.py
@@ -47,7 +47,7 @@ def test_list_plugins(run_spikee, workspace_dir):
 
     output_lines = spikee_list(run_spikee, workspace_dir, "plugins")
     expected_local = {"test_repeat", "test_upper"}
-    expected_builtin = {"1337", "base64", "hex"}
+    expected_builtin = {"1337", "base32", "base64", "hex"}
     _assert_contains(output_lines, expected_local | expected_builtin)
 
 


### PR DESCRIPTION
## Summary

Adds a **Base32** encoding plugin, completing the encoding family alongside the existing `base64`, `hex`, `binary`, `octal`, and `decimal` plugins.

Base32 uses the `A-Z2-7` alphabet, so it tokenises differently from Base64 and can slip past guardrails/filters that only account for Base64-style payloads — a distinct obfuscation vector for evaluation.

## Changes

- `spikee/plugins/base32.py` — new plugin, mirrors the structure of `base64.py` (subclasses `Plugin`, tagged `ENCODING`).
- `tests/functional/test_spikee_list.py` — assert `base32` is discoverable via `spikee list plugins`.
- `docs/02_builtin.md` — add `base32` to the built-in plugins reference table.

## Usage

```
spikee generate --plugins base32
```

## Testing

- `spikee list plugins` shows `base32` under Encoding.
- Verified encode output through spikee's own module loader.
- All functional tests pass locally (`test_spikee_list`, `test_module_loading`, and the full `test_spikee_generate` suite — 113 passed).